### PR TITLE
Implement MongoDB models and authentication

### DIFF
--- a/business-site/lib/mongodb.ts
+++ b/business-site/lib/mongodb.ts
@@ -1,0 +1,22 @@
+import mongoose from 'mongoose';
+
+const MONGODB_URI = process.env.MONGODB_URI || '';
+
+if (!MONGODB_URI) {
+  throw new Error('Please define the MONGODB_URI environment variable');
+}
+
+let cached: { conn: typeof mongoose | null; promise: Promise<typeof mongoose> | null } = (global as any).mongoose;
+
+if (!cached) {
+  cached = (global as any).mongoose = { conn: null, promise: null };
+}
+
+export default async function dbConnect(): Promise<typeof mongoose> {
+  if (cached.conn) return cached.conn;
+  if (!cached.promise) {
+    cached.promise = mongoose.connect(MONGODB_URI);
+  }
+  cached.conn = await cached.promise;
+  return cached.conn;
+}

--- a/business-site/middleware.ts
+++ b/business-site/middleware.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+
+export async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  if (pathname.startsWith('/api/auth')) {
+    return NextResponse.next();
+  }
+
+  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+
+  if (pathname.startsWith('/api') || pathname.startsWith('/admin')) {
+    if (!token || token.role !== 'admin') {
+      const url = req.nextUrl.clone();
+      url.pathname = '/login';
+      return NextResponse.redirect(url);
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/api/:path*', '/admin/:path*'],
+};

--- a/business-site/models/Catalog.ts
+++ b/business-site/models/Catalog.ts
@@ -1,0 +1,15 @@
+import mongoose, { Schema, Document, Model } from 'mongoose';
+
+export interface ICatalog extends Document {
+  title: string;
+  pdfUrl: string;
+  createdAt: Date;
+}
+
+const CatalogSchema = new Schema<ICatalog>({
+  title: { type: String, required: true },
+  pdfUrl: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+export default (mongoose.models.Catalog as Model<ICatalog>) || mongoose.model<ICatalog>('Catalog', CatalogSchema);

--- a/business-site/models/Certificate.ts
+++ b/business-site/models/Certificate.ts
@@ -1,0 +1,18 @@
+import mongoose, { Schema, Document, Model } from 'mongoose';
+
+export interface ICertificate extends Document {
+  title: string;
+  pdfUrl: string;
+  issueDate: Date;
+  description?: string;
+}
+
+const CertificateSchema = new Schema<ICertificate>({
+  title: { type: String, required: true },
+  pdfUrl: { type: String, required: true },
+  issueDate: { type: Date, required: true },
+  description: { type: String },
+});
+
+export default (mongoose.models.Certificate as Model<ICertificate>) ||
+  mongoose.model<ICertificate>('Certificate', CertificateSchema);

--- a/business-site/models/Photo.ts
+++ b/business-site/models/Photo.ts
@@ -1,0 +1,17 @@
+import mongoose, { Schema, Document, Model } from 'mongoose';
+
+export interface IPhoto extends Document {
+  title: string;
+  description?: string;
+  imageUrl: string;
+  createdAt: Date;
+}
+
+const PhotoSchema = new Schema<IPhoto>({
+  title: { type: String, required: true },
+  description: { type: String },
+  imageUrl: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+export default (mongoose.models.Photo as Model<IPhoto>) || mongoose.model<IPhoto>('Photo', PhotoSchema);

--- a/business-site/models/User.ts
+++ b/business-site/models/User.ts
@@ -1,0 +1,17 @@
+import mongoose, { Schema, Document, Model } from 'mongoose';
+
+export interface IUser extends Document {
+  email: string;
+  password: string;
+  role: 'admin' | 'user';
+}
+
+const UserSchema = new Schema<IUser>({
+  email: { type: String, required: true, unique: true },
+  password: { type: String, required: true },
+  role: { type: String, enum: ['admin', 'user'], required: true, default: 'user' },
+});
+
+UserSchema.index({ email: 1 }, { unique: true });
+
+export default (mongoose.models.User as Model<IUser>) || mongoose.model<IUser>('User', UserSchema);

--- a/business-site/pages/api/auth/[...nextauth].ts
+++ b/business-site/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,44 @@
+import { NextApiHandler } from 'next';
+import NextAuth, { NextAuthOptions } from 'next-auth';
+import CredentialsProvider from 'next-auth/providers/credentials';
+import { createHash } from 'crypto';
+import dbConnect from '../../../lib/mongodb';
+import User from '../../../models/User';
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'text' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        await dbConnect();
+        const email = credentials?.email;
+        const password = credentials?.password;
+        if (!email || !password) return null;
+        const user = await User.findOne({ email });
+        if (!user) return null;
+        const hash = createHash('sha256').update(password).digest('hex');
+        if (hash !== user.password) return null;
+        return { id: user._id.toString(), email: user.email, role: user.role };
+      },
+    }),
+  ],
+  session: { strategy: 'jwt' },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) token.role = (user as any).role;
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user) (session.user as any).role = token.role;
+      return session;
+    },
+  },
+  secret: process.env.NEXTAUTH_SECRET,
+};
+
+const handler: NextApiHandler = (req, res) => NextAuth(req, res, authOptions);
+export default handler;

--- a/business-site/pages/api/session.ts
+++ b/business-site/pages/api/session.ts
@@ -1,0 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from './auth/[...nextauth]';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+  return res.json({ user: session.user });
+}

--- a/business-site/pages/login.tsx
+++ b/business-site/pages/login.tsx
@@ -1,0 +1,24 @@
+import { getCsrfToken } from 'next-auth/react';
+import type { GetServerSideProps } from 'next';
+
+export default function Login({ csrfToken }: { csrfToken: string }) {
+  return (
+    <form method="post" action="/api/auth/callback/credentials">
+      <input name="csrfToken" type="hidden" defaultValue={csrfToken} />
+      <div>
+        <label>Email</label>
+        <input name="email" type="email" />
+      </div>
+      <div>
+        <label>Password</label>
+        <input name="password" type="password" />
+      </div>
+      <button type="submit">Sign in</button>
+    </form>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const csrfToken = await getCsrfToken(context);
+  return { props: { csrfToken } };
+};


### PR DESCRIPTION
## Summary
- create MongoDB connection helper
- add Mongoose models for User, Photo, Certificate and Catalog
- configure NextAuth credentials provider
- expose session API
- add middleware for admin access
- add simple login page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6888ad69ef00832aa2bf32c79b5fcc41